### PR TITLE
Fixed the workshops link

### DIFF
--- a/decks/leap.mdx
+++ b/decks/leap.mdx
@@ -144,7 +144,7 @@ To learn more about Leap, review the pages below.
 
 • View Leap's [open source schematics](https://github.com/kevin200617/Orpheus-Leap-Micro).
 
-• Explore [Hack Club Workshops for Leap](https:/workshops.hackclub.com).
+• Explore [Hack Club Workshops for Leap](https://workshops.hackclub.com).
 
 </Box>
 


### PR DESCRIPTION
When I clicked on the workshops link I got a 404 error but it should be fixed now.